### PR TITLE
Adds date archives by month to the mix

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -22,9 +22,11 @@ paginate_path: "blog/page/:num"
 jekyll-archives:
   enabled:
     - 'tags'
+    - 'month'
   layout: tag_index
   permalinks:
     tag: '/tags/:name/'
+    month: '/:year/:month/'
 
 collections:
   team:


### PR DESCRIPTION
Thanks to a robust archive template, we can now offer archives by month and year. Navigate to …/2016/06/ and you see all the posts we wrote in June, 2016. This is a feature that's been requested before but we never had the template for it.
