### PR TITLE
Add "How we work," "Hire 18F," and "Join 18F" pages

### DIFF
--- a/_includes/feature-image.html
+++ b/_includes/feature-image.html
@@ -1,0 +1,5 @@
+{% if page.image %}
+  {% unless page.image_hero == false %}
+    <div class="post-feature_image" style="background-image: url('{{ site.baseurl }}{{ page.image }}')"></div>
+  {% endunless  %}
+{% endif %}

--- a/_includes/footer/desktop.html
+++ b/_includes/footer/desktop.html
@@ -10,16 +10,16 @@
   <div class="footer-links">
     <ul>
       <li>
-        <a href="#">What we deliver</a>
+        <a href="{{ site.baseurl }}/what-we-deliver/">What we deliver</a>
       </li>
       <li>
-        <a href="#">Hire 18F</a>
+        <a href="{{ site.baseurl }}/hire/">Hire 18F</a>
       </li>
       <li>
-        <a href="#">Join 18F</a>
+        <a href="{{ site.baseurl }}/join/">Join 18F</a>
       </li>
       <li>
-        <a href="#">Blog</a>
+        <a href="{{ site.baseurl }}/blog/">Blog</a>
       </li>
     </ul>
   </div>
@@ -27,10 +27,10 @@
     <h5 class="footer-links-heading">Resources</h5>
     <ul>
       <li>
-        <a href="#">Open 18F</a>
+        <a href="{{ site.baseurl }}/#">Open 18F</a>
       </li>
       <li>
-        <a href="#">Standards & policies</a>
+        <a href="{{ site.baseurl }}/#">Standards & policies</a>
       </li>
     </ul>
   </div>
@@ -38,13 +38,13 @@
     <h5 class="footer-links-heading">Contact us</h5>
     <ul>
       <li>
-        <a href="#">Press</a>
+        <a href="{{ site.baseurl }}/#">Press</a>
       </li>
       <li>
-        <a href="#">@18F</a>
+        <a href="https://twitter.com/18F">@18F</a>
       </li>
       <li>
-        <a href="#">18F@gsa.gov</a>
+        <a href="mailto:18F@gsa.gov">18F@gsa.gov</a>
       </li>
     </ul>
   </div>

--- a/_includes/footer/mobile.html
+++ b/_includes/footer/mobile.html
@@ -6,16 +6,16 @@
       </button>
       <ul id="amendment-1" class="usa-accordion-content usa-sidenav-sub_list">
         <li>
-          <a href="#">What we deliver</a>
+          <a href="{{ site.baseurl }}/what-we-deliver/">What we deliver</a>
         </li>
         <li>
-          <a href="#">Hire 18F</a>
+          <a href="{{ site.baseurl }}/hire/">Hire 18F</a>
         </li>
         <li>
-          <a href="#">Join 18F</a>
+          <a href="{{ site.baseurl }}/join/">Join 18F</a>
         </li>
         <li>
-          <a href="#">Blog</a>
+          <a href="{{ site.baseurl }}/blog/">Blog</a>
         </li>
       </ul>
     </li>
@@ -25,13 +25,10 @@
       </button>
       <ul id="amendment-2" class="usa-accordion-content usa-sidenav-sub_list">
         <li>
-          <a href="#">Newsletter</a>
+          <a href="{{ site.baseurl }}/#">Open 18F</a>
         </li>
         <li>
-          <a href="#">Open 18F</a>
-        </li>
-        <li>
-          <a href="#">Standards & policies</a>
+          <a href="{{ site.baseurl }}/#">Standards & policies</a>
         </li>
       </ul>
     </li>
@@ -41,13 +38,13 @@
       </button>
       <ul id="amendment-3" class="usa-accordion-content usa-sidenav-sub_list">
         <li>
-          <a href="#">Press</a>
+          <a href="{{ site.baseurl }}/#">Press</a>
         </li>
         <li>
-          <a href="#">@18F</a>
+          <a href="https://twitter.com/18F">@18F</a>
         </li>
         <li>
-          <a href="#">18F@gsa.gov</a>
+          <a href="mailto:18F@gsa.gov">18F@gsa.gov</a>
         </li>
       </ul>
     </li>

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -7,17 +7,17 @@
     </a>
   </li>
   <li>
-    <a {% if current[1] == 'how-we-work' %}class="usa-current"{% endif %} href="#">
+    <a {% if current[1] == 'how-we-work' %}class="usa-current"{% endif %} href="{{ site.baseurl }}/how-we-work/">
       <span>How we work</span>
     </a>
   </li>
   <li>
-    <a {% if current[1] == 'hire-18f' %}class="usa-current"{% endif %} href="#">
+    <a {% if current[1] == 'hire-18f' %}class="usa-current"{% endif %} href="{{ site.baseurl }}/hire/">
       <span>Hire 18F</span>
     </a>
   </li>
   <li>
-    <a {% if current[1] == 'join-18f' %}class="usa-current"{% endif %} href="#">
+    <a {% if current[1] == 'join-18f' %}class="usa-current"{% endif %} href="{{ site.baseurl }}/join/">
       <span>Join 18F</span>
     </a>
   </li>

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -12,12 +12,12 @@
     </a>
   </li>
   <li>
-    <a {% if current[1] == 'hire-18f' %}class="usa-current"{% endif %} href="{{ site.baseurl }}/hire/">
+    <a {% if current[1] == 'hire' %}class="usa-current"{% endif %} href="{{ site.baseurl }}/hire/">
       <span>Hire 18F</span>
     </a>
   </li>
   <li>
-    <a {% if current[1] == 'join-18f' %}class="usa-current"{% endif %} href="{{ site.baseurl }}/join/">
+    <a {% if current[1] == 'join' %}class="usa-current"{% endif %} href="{{ site.baseurl }}/join/">
       <span>Join 18F</span>
     </a>
   </li>

--- a/_layouts/default-image.html
+++ b/_layouts/default-image.html
@@ -1,0 +1,12 @@
+---
+layout: default
+---
+
+{% include feature-image.html %}
+
+<section class="usa-grid content-focus">
+  {% if page.lead %}
+    <h3>{{ page.lead }}</h3>
+  {% endif %}
+  {{ content }}
+</section>

--- a/_layouts/default-image.html
+++ b/_layouts/default-image.html
@@ -5,6 +5,7 @@ layout: default
 {% include feature-image.html %}
 
 <section class="usa-grid content-focus">
+  <h1 class="usa-sr-only">{{ page.title }}</h1>
   {% if page.lead %}
     <h3>{{ page.lead }}</h3>
   {% endif %}

--- a/_layouts/default-intro.html
+++ b/_layouts/default-intro.html
@@ -14,4 +14,6 @@ layout: default
     </header>
   </div>
 </section>
+<section class="usa-grid usa-section usa-content">
 {{ content }}
+</section>

--- a/_layouts/default-intro.html
+++ b/_layouts/default-intro.html
@@ -15,5 +15,5 @@ layout: default
   </div>
 </section>
 <section class="usa-grid usa-section usa-content">
-{{ content }}
+  {{ content }}
 </section>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -2,11 +2,7 @@
 layout: default
 ---
 
-{% if page.image %}
-  {% unless page.image_hero == false %}
-    <div class="post-feature_image" style="background-image: url('{{ site.baseurl }}{{ page.image }}')"></div>
-  {% endunless  %}
-{% endif %}
+{% include feature-image.html %}
 
 <div class="usa-grid">
 

--- a/_sass/_components/buttons.scss
+++ b/_sass/_components/buttons.scss
@@ -2,12 +2,17 @@
 // ==========================
 
 .usa-button,
-.usa-button:visited {
+.usa-button:visited,
+button,
+[type="button"],
+[type="submit"],
+[type="reset"],
+[type="image"] {
   background-color: $color-medium;
   font-family: $font-sans;
 
   &:hover {
-    background-color: $color-dark;
+    background-color: $color-medium-hover;
   }
 
   &.usa-button-secondary,

--- a/_sass/_components/footer.scss
+++ b/_sass/_components/footer.scss
@@ -153,14 +153,9 @@ footer[role=contentinfo] {
 
   [type="submit"] {
     @include margin(1.7rem 0 null 1rem);
-    background-color: $color-medium;
     display: inline;
     font-family: $font-sans; // TODO: remove this when we fix variables import
     padding: 0;
     width: 8rem;
-
-    &:hover {
-      background-color: $color-medium-hover;
-    }
   }
 }

--- a/_sass/_components/layout.scss
+++ b/_sass/_components/layout.scss
@@ -134,3 +134,14 @@
     margin-bottom: 0;
   }
 }
+
+.content-focus {
+  @include margin(0 null $section-margins null);
+
+  @include media($medium-screen + 200px) {
+    @include margin($section-margins auto);
+    max-width: 61rem;
+  }
+}
+
+

--- a/_sass/_components/layout.scss
+++ b/_sass/_components/layout.scss
@@ -136,12 +136,8 @@
 }
 
 .content-focus {
-  @include margin(0 null $section-margins null);
-
-  @include media($medium-screen + 200px) {
-    @include margin($section-margins auto);
-    max-width: 61rem;
-  }
+  @include margin($section-margins auto);
+  max-width: 61rem;
 }
 
 

--- a/_sass/_components/layout.scss
+++ b/_sass/_components/layout.scss
@@ -139,5 +139,3 @@
   @include margin($section-margins auto);
   max-width: 61rem;
 }
-
-

--- a/_sass/_templates/what-we-deliver.scss
+++ b/_sass/_templates/what-we-deliver.scss
@@ -18,4 +18,8 @@
       margin-right: 0; // Remove column gutter on the right
     }
   }
+
+  .usa-content {
+    @include padding(0 null);
+  }
 }

--- a/pages/feature-image-test.md
+++ b/pages/feature-image-test.md
@@ -1,0 +1,28 @@
+---
+title: Join 18F
+permalink: /feature-image/
+layout: default-image
+lead: Now’s the time to get involved in transforming how the federal government does technology. Join the digital services movement.
+image: /assets/blog/every-kid-in-a-park/glacier-park.jpg
+---
+
+We’re looking for candidates passionate about our mission, with
+top-notch software development, design, content, and operations skills
+to match. We’re a remote-first team with offices in Washington D.C, New
+York City, Chicago, and San Francisco, but we also have teammates working in 26 other cities all over the country. [Read more about how
+we make our distributed model
+work](https://18f.gsa.gov/2015/10/15/best-practices-for-distributed-teams/).
+
+We’re a tech office, but [our employees](https://18f.gsa.gov/team/)
+have a wide range of skills and come from diverse backgrounds. Read how
+our employees describe, in their own words, [why they joined
+18F](https://18f.gsa.gov/2016/03/21/we-asked-100-of-our-coworkers-why-did-you-join-18f/)
+and [the path they took to get
+here](https://18f.gsa.gov/2016/03/22/what-was-your-path-to-18f/).
+
+If you’re interested in joining 18F, you can learn more about the
+interview process, government pay grades, benefits, and our open
+positions at
+[join.18f.gov](https://pages.18f.gov/joining-18f/index.html).
+
+<a class="usa-button" href="https://pages.18f.gov/joining-18f/open-positions/">View open positions</a>

--- a/pages/hire.md
+++ b/pages/hire.md
@@ -1,0 +1,28 @@
+---
+title: Hire 18F
+permalink: /hire/
+layout: default-intro
+lead: Let’s work together to design services that empower your team, better serve the public, and tackle the big problems facing your agency.
+---
+
+18F is available for short- and long-term engagements with federal
+agencies, the D.C. government, and to assist with projects that receive
+federal grants to state and local agencies. We can work with you to
+explore and define a variety of problems, and then we can help you build
+or buy a solution.
+
+Because of our limited resources, 18F is not able to take on every
+project that agencies propose. We select our projects through a
+qualification and evaluation process led by our Agency Partnerships
+Team. If you and 18F decide that we’re the right fit for a project and
+we have the necessary time and resources, we’ll work with you to draft
+the necessary documents to begin our partnership. You can read more
+about how we work with other agencies in our [Partnership
+Playbook](https://pages.18f.gov/partnership-playbook/).
+
+18F is a cost-recoverable office, which means that we do not receive
+appropriated funds from Congress and must charge our partner agencies to
+cover our costs. Funding is set up through [Interagency
+Agreements](https://pages.18f.gov/iaa-forms/).
+
+Do you have a project in mind? Let us know: [inquiries18F@gsa.gov](mailto:inquiries18F@gsa.gov)

--- a/pages/how-we-work.md
+++ b/pages/how-we-work.md
@@ -1,0 +1,18 @@
+---
+title: How we work
+permalink: /how-we-work/
+layout: default-intro
+lead: We’ll work hand-in-hand with your team, use modern techniques, and talk with real users to build the right thing, not just any thing.
+---
+
+We find our way through every project by putting the needs of the public
+first. We use [human-centered design, agile methodologies, and open
+source software](https://playbook.cio.gov/) to build world-class digital services for the American
+public. We’re committed to working in the open, building accessible
+products, and deploying early and often.
+
+See exactly how we put all of those principles into practice by reading
+through our guides on [accessibility](https://pages.18f.gov/accessibility/),
+[CSS coding style](https://pages.18f.gov/frontend/css-coding-styleguide/), [open source projects](https://pages.18f.gov/open-source-guide/), [content](https://pages.18f.gov/content-guide/), [lean product design](https://pages.18f.gov/lean-product-design/),
+and [more](https://pages.18f.gov/guides/). We’re public about the standards we use, and we publish any
+guidance we create for our staff.

--- a/pages/join.md
+++ b/pages/join.md
@@ -23,3 +23,5 @@ If you’re interested in joining 18F, you can learn more about the
 interview process, government pay grades, benefits, and our open
 positions at
 [join.18f.gov](https://pages.18f.gov/joining-18f/index.html).
+
+<a class="usa-button" href="https://pages.18f.gov/joining-18f/open-positions/">View open positions</a>

--- a/pages/join.md
+++ b/pages/join.md
@@ -1,0 +1,25 @@
+---
+title: Join 18F
+permalink: /join/
+layout: default-intro
+lead: Now’s the time to get involved in transforming how the federal government does technology. Join the digital services movement.
+---
+
+We’re looking for candidates passionate about our mission, with
+top-notch software development, design, content, and operations skills
+to match. We’re a remote-first team with offices in Washington D.C, New
+York City, Chicago, and San Francisco, but we also have teammates working in 26 other cities all over the country. [Read more about how
+we make our distributed model
+work](https://18f.gsa.gov/2015/10/15/best-practices-for-distributed-teams/).
+
+We’re a tech office, but [our employees](https://18f.gsa.gov/team/)
+have a wide range of skills and come from diverse backgrounds. Read how
+our employees describe, in their own words, [why they joined
+18F](https://18f.gsa.gov/2016/03/21/we-asked-100-of-our-coworkers-why-did-you-join-18f/)
+and [the path they took to get
+here](https://18f.gsa.gov/2016/03/22/what-was-your-path-to-18f/).
+
+If you’re interested in joining 18F, you can learn more about the
+interview process, government pay grades, benefits, and our open
+positions at
+[join.18f.gov](https://pages.18f.gov/joining-18f/index.html).

--- a/pages/what-we-deliver.md
+++ b/pages/what-we-deliver.md
@@ -5,7 +5,7 @@ layout: default-intro
 lead: We help federal agencies build, buy, and share modern digital services to improve the user experience of government.
 ---
 
-<section class="usa-grid usa-section section-list">
+<section class="usa-grid-full usa-section section-list">
   <div class="usa-width-one-third">
     <img class="usa-img-circle" src="{{ site.baseurl }}/assets/img/home-icons/custom-products.svg" alt="">
   </div>
@@ -23,7 +23,7 @@ If your agency’s project has a digital component, our team of software develop
   </div>
 </section>
 
-<section class="usa-grid usa-section section-list">
+<section class="usa-grid-full usa-section section-list">
   <div class="usa-width-one-third">
     <img src="{{ site.baseurl }}/assets/img/home-icons/innovative-ways.svg" alt="">
   </div>
@@ -43,7 +43,7 @@ our team is excited to work with you. We can help you:
   </div>
 </section>
 
-<section class="usa-grid usa-section section-list">
+<section class="usa-grid-full usa-section section-list">
   <div class="usa-width-one-third">
     <img src="{{ site.baseurl }}/assets/img/home-icons/government.svg" alt="">
   </div>
@@ -64,7 +64,7 @@ actively improved to meet your needs. We can help you:
   </div>
 </section>
 
-<section class="usa-grid usa-section section-list">
+<section class="usa-grid-full usa-section section-list">
   <div class="usa-width-one-third">
     <img src="{{ site.baseurl }}/assets/img/home-icons/path.svg" alt="">
   </div>
@@ -84,7 +84,7 @@ you form new digital habits, and ultimately drive organizational culture change.
   </div>
 </section>
 
-<section class="usa-grid usa-section section-list">
+<section class="usa-grid-full usa-section section-list">
   <div class="usa-width-one-third">
     <img src="{{ site.baseurl }}/assets/img/home-icons/modern-techniques.svg" alt="">
   </div>

--- a/pages/what-we-deliver.md
+++ b/pages/what-we-deliver.md
@@ -15,10 +15,12 @@ lead: We help federal agencies build, buy, and share modern digital services to 
 
 If your agency’s project has a digital component, our team of software developers, visual designers, writers, and security experts can help you build it. We can help you:
 
-- Improve a process for users, like we did with the [U.S. Citizenship and Immigration Service](https://my.uscis.gov/).
-- Build a new site to showcase your data, like we did with Department of Education's [College Scorecard](https://collegescorecard.ed.gov/).
-- Revamp your online presence — from data to branding and everything in between — like we did with the [Federal Election Commission](https://beta.fec.gov/).
-- Scope a solution or workshop an idea, like we did with the [Department of Labor’s Wage and Hour Division](https://18f.gsa.gov/2015/09/09/how-a-two-day-spring-moved-an-agency-twenty-years-forward/).
+- Improve a challenging user process by reimagining a daunting task, as we did with the [U.S. Citizenship and Immigration Service](https://my.uscis.gov/) and their immigration and visa processes
+- Build a new site and API to showcase and synthesize data from multiple sources, as we did with Department of Education's [College Scorecard](https://collegescorecard.ed.gov/)
+- Help you make your data more accessible with a user-friendly site and developer tools, as we did with the [Federal Election Commission](https://beta.fec.gov/)
+- Build web-based tools to streamline internal agency processes, as we did with [Communicart](https://cap.18f.gov/) and [CALC](https://calc.gsa.gov/)
+- Scope a solution or collaborate on an idea in a way that empowers you to meet the needs of your users, as we did with the [Department of Labor’s Wage and Hour Division](https://18f.gsa.gov/2015/09/09/how-a-two-day-spring-moved-an-agency-twenty-years-forward/)
+- Do user research and discovery sprints to promote a new digital model that houses information, as we did with NASA and the National Oceanic and Atmospheric Administration’s Climate Discovery project
 {% endmarkdown %}
   </div>
 </section>


### PR DESCRIPTION
Adds "How we work," "Hire 18F," and "Join 18F" pages to the site.

See it live 📺: https://federalist.18f.gov/preview/18F/beta.18f.gov/add-more-pages/

Also adds a feature image layout for pages `_layouts/default-image.html`: https://federalist.18f.gov/preview/18F/beta.18f.gov/add-more-pages/feature-image/

**_Note_**: this is v1 of the design. In the future, a team will develop another design that brings over the 18F pages content.
