### PR TITLE
[Image links]: Remove Firefox patch on media_link class

### DIFF
--- a/_sass/_libs/wds/stylesheets/elements/_figure.scss
+++ b/_sass/_libs/wds/stylesheets/elements/_figure.scss
@@ -11,13 +11,3 @@ img {
 .media_link {
   @include media-link();
 }
-
-// Patch for Firefox: max-width:100% is not respected within auto-width inline
-// blocks
-@-moz-document url-prefix() {
-  .media_link {
-    display: table;
-    table-layout: fixed;
-    width: 100%;
-  }
-}


### PR DESCRIPTION
Mirrors change that will happen on the standards, the patch is not needed as it was fixed by Firefox, it's causing some issues with our image links on FF.

https://github.com/18F/web-design-standards/pull/1332
