### PR TITLE
Adds tests and preps for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+language: ruby
+rvm:
+  - 2.2.3
+
+sudo: false
+cache: bundler
+git:
+  submodules: false
+
+script: 
+  - bundle exec jekyll build
+  - bundle exec tests/test.rb
+  - bundle exec jekyll test
+
+notifications:
+  email:
+    recipients:
+      - elaine.kamlley@gsa.gov
+      - gregory.boone@gsa.gov
+    on_success: change
+    on_failure: change
+
+branches:
+  only:
+    - staging

--- a/tests/schema/_posts.yml
+++ b/tests/schema/_posts.yml
@@ -1,0 +1,19 @@
+---
+title: "String"
+authors:
+  type: Array
+  matches: _data/author.yml
+tags:
+  type: Array
+  rules: [no-dash, lowercase]
+excerpt: "string"
+description: "string"
+config:
+  path: '_posts'
+  ignore:
+  - README.md
+  - ..
+  - .
+  - .DS_Store
+  optional: ['tumblr_url', 'layout', 'date', 'image']
+---

--- a/tests/schema/_team.yml
+++ b/tests/schema/_team.yml
@@ -1,0 +1,20 @@
+---
+first_name: "String"
+last_name: "String"
+full_name: "String"
+role: "String"
+city: "String"
+state: "String"
+team:
+  type: "String"
+  oneof: ["Delivery", "Consulting", "Design", "Talent"]
+role: "String"
+config:
+  path: '_team'
+  ignore:
+  - README.md
+  - ..
+  - .
+  - .DS_Store
+  optional: ['tumblr_url', 'github', 'twitter']
+---

--- a/tests/schema/rules.yml
+++ b/tests/schema/rules.yml
@@ -1,0 +1,4 @@
+no-dash:
+- prohibited: ["-"]
+lowercase:
+- prohibited: ["AZ"]

--- a/tests/test.rb
+++ b/tests/test.rb
@@ -1,0 +1,9 @@
+#!/usr/bin/env ruby
+require 'html-proofer'
+proofer = HTMLProofer.check_directory("./_site", {
+  :directory_index_file => "index.html",
+  :url_ignore => ["/dashboard","18f@gsa.gov"],
+  :disable_external => true,
+  :href_swap => {"%20" => " "}
+})
+proofer.run


### PR DESCRIPTION
This should integrate the same tests we're running on 18f.gsa.gov into the new site. They will likely fail on just about every page right now because we still have some placeholder text linking to `#` but as soon as we clear that up they should start to pass again.
