### PR TITLE
Resolves 508 issues flagged by a11y test

### DIFF
--- a/_layouts/tag-results.html
+++ b/_layouts/tag-results.html
@@ -31,8 +31,9 @@ header_border: true
           </div>
           <div class="usa-width-one-third">
             {% if post.image %}
-              <a class="media_link" href="{{ post.url | prepend: site.baseurl }}">
-                <img src="{{ site.baseurl }}{{ post.image }}">
+              <a class="media_link" href="{{ post.url | prepend: site.baseurl }}" title="link to post">
+                <img src="{{ site.baseurl }}{{ post.image }}" alt="">
+                <p class="usa-sr-only">continue reading</p>
               </a>
             {% endif %}
           </div>

--- a/pages/press.html
+++ b/pages/press.html
@@ -6,7 +6,7 @@ permalink: /press/
 <p>18F is a growing group of technologists, designers, and researchers from around the country who are committed to making government services simpler and easier to use. We put the needs of the American people first, we work in the open to make our products stronger, and we are design-centric, agile, open, and data-driven.</p>
 <p>&quot;If you have questions, we&#39;ve got answers.&quot;</p>
 <p><a href="mailto:media@gsa.gov?Subject=18F%20Media%20Query">media@gsa.gov</a></p>
-<section id="">
+<section>
   <h2 id="what-18f-has-accomplished">What 18F has accomplished</h2>
   <p>
   <h3 id="myuscis">MyUSCIS</h3>
@@ -41,7 +41,7 @@ permalink: /press/
   <p>In two of our first projects, 18F worked with Federal Acquisition Service employees to create <a href="https://discovery.gsa.gov/">market research tools</a> to help write better contracts and <a href="https://calc.gsa.gov/">find better vendors</a> to include in blanket purchase agreements. In addition to GSA contracting officers, <a href="https://18f.gsa.gov/2015/11/10/boston-is-using-gsa-calc-tool/">CALC is also being used by the City of Boston</a>.</p>
   </p>
 </section>
-<section id="">
+<section>
   <h2 id="18f-projects-adapted-by-other-organizations">18F projects adapted by other organizations</h2>
   <p>
   <p>We publish our code repositories <a href="https://github.com/18F">on GitHub</a> and encourage the public to adapt our code and <a href="https://pages.18f.gov/guides/">guides</a> for their own projects.</p>
@@ -65,13 +65,13 @@ permalink: /press/
   </ul>
   </p>
 </section>
-<section id="">
+<section>
   <h2 id="18f-s-relationship-with-the-u-s-digital-service">18F's relationship with the U.S. Digital Service</h2>
   <p>
   <p>18F and the <a href="https://www.whitehouse.gov/digital/united-states-digital-service">U.S. Digital Service</a> are distinct groups working toward the same vision of better digital government. 18F is a digital consultancy in an independent agency (GSA) and provides products and services to federal entities on a fee-for-service basis. The U.S. Digital Service is part of the Executive Office of the President and the United States CIO, supporting and coordinating the work of various digital service teams housed in agencies across the federal government.</p>
   </p>
 </section>
-<section id="">
+<section>
   <h2 id="basic-information-on-18f-s-history">Basic information on 18F’s history</h2>
   <p>
   <ul>
@@ -87,7 +87,7 @@ permalink: /press/
   </ul>
   </p>
 </section>
-<section id="">
+<section>
   <h2 id="how-18f-works">How 18F Works</h2>
   <p>
   <p>18F works in partnership with agencies across government on a reimbursable basis. We delivering public-facing services via web applications, data and service Application Programming Interfaces (APIs), and platforms. 18F operates using three basic models:</p>
@@ -99,7 +99,7 @@ permalink: /press/
   <p>18F is an <a href="https://github.com/18F/open-source-policy">open source team</a>. It uses open source development to transparently promote the security, quality, and modularity of our code and to invite review, participation, and free and simple reuse of our efforts by government agencies, the business community, and the public.</p>
   </p>
 </section>
-<section id="">
+<section>
   <h2 id="how-18f-is-funded">How 18F is funded</h2>
   <p>
   <p>18F charges clients on a break even basis for the services we deliver. Revenue generated from these charges is held in the <a href="http://www.gsa.gov/portal/content/182815">Acquisition Services Fund</a> where it is made available for current and future operating expenses.</p>


### PR DESCRIPTION
Addressed main errors in this a11y test: https://continua11y.18f.gov/18F/beta.18f.gov/3a5c84c6bc8e7260e7297a87d45e1c984223dedd
1. Removed empty `ids` on the press page 
2. Added screen reader only text for `\tag-result.html` images
