### PR TITLE
Fix focus on logo link

### DIFF
--- a/_sass/_components/header.scss
+++ b/_sass/_components/header.scss
@@ -48,13 +48,10 @@ header[role=banner] {
 }
 
 .site-logo {
+  @include margin(1rem null);
   display: block;
-
-  img {
-    @include margin(1rem null);
-    float: left;
-    width: 4.4rem;
-  }
+  float: left;
+  width: 4.4rem;
 }
 
 // scss-lint:disable PropertyCount


### PR DESCRIPTION
Fixes last item on #29.

This is what it looks like when focused:

<img width="257" alt="screen shot 2016-08-12 at 3 24 40 pm" src="https://cloud.githubusercontent.com/assets/5249443/17638743/24c9e95c-60a1-11e6-90ba-49592e44aa8f.png">

cc: @elainekamlley @msecret @gboone 
