### PR TITLE
Adds baseurl to the image paths for these images

### DIFF
--- a/_posts/2015-03-12-day-in-the-life-of-an-18F-content-designer.md
+++ b/_posts/2015-03-12-day-in-the-life-of-an-18F-content-designer.md
@@ -15,54 +15,54 @@ excerpt: "In preparation for our one-year anniversary, we at 18F are introducing
 description: "In preparation for our one-year anniversary, we at 18F are introducing a new blog feature — our Day in the Life Series. Once a month, a different team member will share the details of their typical day in the office. Up first is Kate Garklavs, Content Designer."
 ---
 
-<img alt="Kate Garklavs" src="/assets/blog/day-in-life-content/kate.JPG" class="align-left" />
+<img alt="Kate Garklavs" src="{{ site.baseurl }}/assets/blog/day-in-life-content/kate.JPG" class="align-left" />
 
-In preparation for our one-year anniversary, we at 18F are introducing a new blog feature — our **Day in the Life** Series. Once a month, a different team member will share the details of their typical day in the office. (Well, there are no “typical” days here — only extraordinary ones — but you get the gist.) 
+In preparation for our one-year anniversary, we at 18F are introducing a new blog feature — our **Day in the Life** Series. Once a month, a different team member will share the details of their typical day in the office. (Well, there are no “typical” days here — only extraordinary ones — but you get the gist.)
 
-Up first is Kate Garklavs, 18F’s first content designer. Kate was drawn to 18F by the prospect of increasing the accessibility of written governmental resources. 
+Up first is Kate Garklavs, 18F’s first content designer. Kate was drawn to 18F by the prospect of increasing the accessibility of written governmental resources.
 
 “It’s a pretty universal feeling, being frustrated by government forms with unclear or needlessly complicated language,” Kate told us. “But that’s one reason I wanted to join 18F — to start to create a solution to this problem. My hope is that we’ll get to a point where people are looking to government documents and publications as the standard of clarity.”
 
-On that note, let’s get a glimpse at what a day on the 18F content team is like. Kate, take it away. 
+On that note, let’s get a glimpse at what a day on the 18F content team is like. Kate, take it away.
 
-**7:00 a.m.:** Rise and shine! When my alarm sounds, I hit snooze twice before checking Slack to see what’s happening with my East Coast colleagues. After responding to any urgent messages, I go about the rest of my morning routine — shower, coffee, breakfast, coffee. Because I like my coworkers and want to shield them from the extent of my hanger, I never skip breakfast. And, if you’re curious about the true breakfast of champions, be advised that it’s this: a whole-wheat English muffin (toasted until medium-brown) spread with half of an avocado (mashed), sprinkled with Maldon and dotted with Tapatio. 
+**7:00 a.m.:** Rise and shine! When my alarm sounds, I hit snooze twice before checking Slack to see what’s happening with my East Coast colleagues. After responding to any urgent messages, I go about the rest of my morning routine — shower, coffee, breakfast, coffee. Because I like my coworkers and want to shield them from the extent of my hanger, I never skip breakfast. And, if you’re curious about the true breakfast of champions, be advised that it’s this: a whole-wheat English muffin (toasted until medium-brown) spread with half of an avocado (mashed), sprinkled with Maldon and dotted with Tapatio.
 
 **9:00 a.m.:** Most mornings, I get to the office around 9:00. Per the advice of productiveness gurus everywhere, I try not to check my email until a little later in the morning, but some mornings I check right away — I’m only human, after all. My preference, though, is to dive right into a project.
 
 **9:30 a.m.:** At 9:30, I join my colleagues for the weekly all hands meeting. We’re part of a distributed workforce, and so when the entire group convenes, we do so via digital means (VTC). Every Tuesday, the group meets to discuss major events, project successes, and other news. This weekly meeting is a great way to learn more about what different projects are up to and to touch base with colleagues, wherever they hang their metaphorical hats.
 
-<img alt="all hands meeting" src="/assets/blog/day-in-life-content/allhands.JPG" class="align-center" />
+<img alt="all hands meeting" src="{{ site.baseurl }}/assets/blog/day-in-life-content/allhands.JPG" class="align-center" />
 
 **10:00 a.m.:** Right after the all hands, I meet up with the MyUSA team for our weekly sprint planning meeting. What’s a sprint? I’m glad you asked! In agile parlance, a sprint is a short period of time (usually a week or two) during which a project team aims to complete a fixed number of tasks. It’s an organizational tool that helps teams break down larger projects into smaller, more achievable tasks.
 
 And what’s [MyUSA] (https://my.usa.gov/)? Also glad you asked! MyUSA is a service that will allow citizens to access services from multiple government agencies ([Benefits.gov] (http://www.benefits.gov/), [BusinessUSA] (http://business.usa.gov/), and [USA.gov] (http://www.usa.gov/) among them) through a single account. Citizens will access this account with a single sign on (no need to remember unwieldy passwords), and they’ll be able to track their progress on different tasks — completing and submitting forms, for example. You can think of MyUSA as a one-stop shop for government.
 
-During sprint planning, each team member reviews what they did during the previous sprint and discusses what they’d like to accomplish in the coming one. Recently, I’ve been rewriting the front page copy based on data from user interviews. Many of our interviewees had difficulty making meaning of our value statement, so I’ve focused my efforts on crafting a statement (20 words or fewer) that describes what MyUSA does. Writing 20 words might not seem like much, but conveying the essence of a multifaceted service in a single sentence is much harder than it looks. 
+During sprint planning, each team member reviews what they did during the previous sprint and discusses what they’d like to accomplish in the coming one. Recently, I’ve been rewriting the front page copy based on data from user interviews. Many of our interviewees had difficulty making meaning of our value statement, so I’ve focused my efforts on crafting a statement (20 words or fewer) that describes what MyUSA does. Writing 20 words might not seem like much, but conveying the essence of a multifaceted service in a single sentence is much harder than it looks.
 
 **11:00 a.m.:** After wrapping up sprint planning, I meet with Greg and other members of the blog team for the **blog huddle**. Modeled a bit after writing workshops and drawing on techniques used at university writing centers, the huddle is a drop-in workshop during which anyone can get advice on blogging and feedback on their drafts. It’s only been around for a month or so, but it’s already proving to be popular.
 
-During today’s huddle, a coworker asks for advice on how to write about part of a project that didn’t pan out, but in a way that doesn’t upset the client. I recommend leading in by discussing parts of the project that did work out, as well as reframing the mishap: that is, describing how it allowed the project to pivot (and move in a more successful direction). I also remind my colleague to send the client his draft before sending the draft for additional approval; getting your subject’s thumbs-up before publication is vital to maintaining successful relationships. 
+During today’s huddle, a coworker asks for advice on how to write about part of a project that didn’t pan out, but in a way that doesn’t upset the client. I recommend leading in by discussing parts of the project that did work out, as well as reframing the mishap: that is, describing how it allowed the project to pivot (and move in a more successful direction). I also remind my colleague to send the client his draft before sending the draft for additional approval; getting your subject’s thumbs-up before publication is vital to maintaining successful relationships.
 
 **Noon:** After a busy morning, I’m ready to step away from my screen and put some food in my face. Lunch around these parts is always a lively event. I tend to bring my lunch — when I’m not writing or reading, I’m trying new recipes — but on Thursdays, the SF team has its weekly potluck.
 
-Does the term potluck cause you to wrinkle your nose or reflexively cast a withering glance at whomever spoke the word? Don’t be fooled: Our potlucks are second to none. Some weeks, we assemble a feast from food-truck fare (though we have some dedicated home cooks, as well). Recently, we held our first themed potluck: Taco Thursday. The spread featured tortillas, carnitas, black beans and kale, guacamole, salsas rojo and verde, fried plantains, and eggs and nopales — all homemade, to boot. 
+Does the term potluck cause you to wrinkle your nose or reflexively cast a withering glance at whomever spoke the word? Don’t be fooled: Our potlucks are second to none. Some weeks, we assemble a feast from food-truck fare (though we have some dedicated home cooks, as well). Recently, we held our first themed potluck: Taco Thursday. The spread featured tortillas, carnitas, black beans and kale, guacamole, salsas rojo and verde, fried plantains, and eggs and nopales — all homemade, to boot.
 
-At 18F, the spirit of innovation prevails, even in our approach to lunch. 
+At 18F, the spirit of innovation prevails, even in our approach to lunch.
 
-<div class="align-center" ><img alt="making tortillas" src="/assets/blog/day-in-life-content/tacos1.JPG" class="align-left" />
-<img alt="delicious homemade taco" src="/assets/blog/day-in-life-content/tacos2.JPG" class="align-right" /></div>
+<div class="align-center" ><img alt="making tortillas" src="{{ site.baseurl }}/assets/blog/day-in-life-content/tacos1.JPG" class="align-left" />
+<img alt="delicious homemade taco" src="{{ site.baseurl }}/assets/blog/day-in-life-content/tacos2.JPG" class="align-right" /></div>
 
-**1:00 p.m.:** With lunch over, it’s time to get back to work. After a quick check of the inbox, I start some revisions of site copy for openFOIA, which helps folks make [FOIA] (http://www.foia.gov/) (Freedom of Information Act) requests more easily and efficiently. 
+**1:00 p.m.:** With lunch over, it’s time to get back to work. After a quick check of the inbox, I start some revisions of site copy for openFOIA, which helps folks make [FOIA] (http://www.foia.gov/) (Freedom of Information Act) requests more easily and efficiently.
 
-As I review each chunk of copy, I keep a few factors in mind: what phrasings and definitions we’re legally required to use, which phrasings we aren’t, and how I can describe the central concepts in a way that appeals to the viewer. Whenever possible, I replace long words with shorter ones, acronyms with agency names, and legal jargon with plain language. 
+As I review each chunk of copy, I keep a few factors in mind: what phrasings and definitions we’re legally required to use, which phrasings we aren’t, and how I can describe the central concepts in a way that appeals to the viewer. Whenever possible, I replace long words with shorter ones, acronyms with agency names, and legal jargon with plain language.
 
 **3:00 p.m.:** Later in the afternoon, I meet with my colleague Nick to discuss the next event in the 18F Presents series. Roughly once a month, 18F brings in a noted speaker from the field of visual design, UX, or content. (Our first speaker was Steve Portigal — read more about the event [here] (https://18f.gsa.gov/2015/02/26/Five-Ways-To-Turn-A-Bad-Idea-Into-A-Great-One/).)
 
-Nick and I are helping to organize the series, and today we’re creating a survey to collect people’s thoughts on who we should invite. I also work on drafting email templates to send to speakers at different points before the event; creating these templates now saves time in the long run. 
+Nick and I are helping to organize the series, and today we’re creating a survey to collect people’s thoughts on who we should invite. I also work on drafting email templates to send to speakers at different points before the event; creating these templates now saves time in the long run.
 
 **4:00 p.m.:** As we head into late afternoon, I make some mint tea and comment on a few blog post drafts. One of my favorite parts of working at 18F is collaborating with my coworkers. Ours is a crew practiced in offering thoughtful, well-worded insights — and offering them quickly. Though some posts take longer to write and publish, many of our posts (500 to 1,000 words) have a two- or three-day turnaround time — nothing to sneeze at, when you factor in government-specific review and regulatory processes.
 
-**5:30 p.m.:** At half past five, the whistle blows; in the case of the SF office, this translates to the overhead lights starting to dim. Energy-saving measure or hint to head homeward? I interpret it as the latter. 
+**5:30 p.m.:** At half past five, the whistle blows; in the case of the SF office, this translates to the overhead lights starting to dim. Energy-saving measure or hint to head homeward? I interpret it as the latter.
 
 Discarding my spent to-do list before I go, I bid farewell to 50 UN Plaza and start my walk home through the friscalating dusklight of SOMA. Most nights I listen to a podcast as I walk; lately, I’m digging [Invisibilia] (http://www.npr.org/programs/invisibilia/) and [The Allusionist] (http://www.theallusionist.org/) (and am always open to suggestions, so please send yours!). Some nights, though, I’m content to just walk, listening to the clatter of the F as it edges away from downtown, the conversations — muted and shouted — of my fellow passersby.
 

--- a/_posts/2015-04-06-day-in-the-life-of-talent-manager.md
+++ b/_posts/2015-04-06-day-in-the-life-of-talent-manager.md
@@ -18,7 +18,7 @@ excerpt: "For this month's installment of our Day in the Life series, Talent Man
 
 A little more than a year ago, I came to 18F as a Returned Peace Corps Volunteer (RPCV El Salvador 2011-2013) and joined the team as one of the first Operations Specialists. At the time, 18F was still in its infancy; actually, we weren’t even 18F yet. Besides lacking a formal name, we were also light on staff — in terms of numbers, that is. At that time, we had just ten big-hearted problem solvers who believed they could transform government. Though they were small in number, their spirit was invigorating and I knew I had to join them.
 
-<img alt="Jamie Albrecht" src="/assets/blog/talent-manager/Jamie.jpg" class="align-left" />
+<img alt="Jamie Albrecht" src="{{ site.baseurl }}/assets/blog/talent-manager/Jamie.jpg" class="align-left" />
 
 I spent my first few months at 18F on the Operations Team — the heart and soul of our organization, in my very biased opinion. I focused on asking lots of questions and attempting to figure out how to operationalize a new office inside the federal government. The Ops Team tackled everything from hiring to budget to purchase requests to securing space for our then upcoming offices, like San Francisco, Chicago, and New York. In short, we took care of all the things that needed to happen for 18F to work, in a very practical sense.
 
@@ -30,7 +30,7 @@ Today, I am a talent manager in our San Francisco office, and this is a day in m
 
 My morning routine is easy, quick, and simple. The only things I take too seriously at this hour are tea, fruit, and yogurt. I’m out the door and walking to work by 6:00 a.m.
 
-<img alt="My morning walk to work" src="/assets/blog/talent-manager/morningwalk.JPG" class="align-left" />
+<img alt="My morning walk to work" src="{{ site.baseurl }}/assets/blog/talent-manager/morningwalk.JPG" class="align-left" />
 
 **7:00 a.m.**: Wednesday is farmers' market day at 50 UN Plaza, which means breakfast (part two) is too many free samples of chocolate almond brittle. At this hour, no one else is around, so I crank up our Bose speakers and unleash DJ JME. I make all my co-workers listen to [this song] (https://www.youtube.com/watch?v=sZ-D4jmkUiQ) at least once. You should listen, too. It helps me work through my priority inbox and prepare my notes for my morning meetings.
 
@@ -44,7 +44,7 @@ At **10:00 a.m.** I check in with our main GSA HR point of contact. We talk dail
 
 By **noon**, I am ready for a break. My SF officemates know that my lunch habits are typically atrocious, and they often chastise me. Today, I wander the farmer’s market eating pretzel M&Ms, gathering samples of apples and oranges, buying dates (the fruit, not the social event), and of course stopping for another round of almond brittle.
 
-<img alt="SF on a sunny day" src="/assets/blog/talent-manager/sfview.JPG" class="align-right" />
+<img alt="SF on a sunny day" src="{{ site.baseurl }}/assets/blog/talent-manager/sfview.JPG" class="align-right" />
 
 **1:00 p.m.**: I make my way back inside and settle in to review resumes. This task is fairly simple: input names and other pertinent information into our candidate tracker, separate applicants into the appropriate [buckets] (https://18f.gsa.gov/2015/03/10/Labor-Category-Descriptions-for-Agile-Procurements/), and then send the resumes out  for evaluation. Each resume is reviewed by at least two subject matter experts (SMEs) on our team.
 
@@ -52,7 +52,7 @@ By **noon**, I am ready for a break. My SF officemates know that my lunch habits
 
 **3:30 p.m.**: After three phone calls, I am ready for my mid-afternoon break. I like to hula-hoop around the office. I’ve made it my mission to teach the rest of the office. Luckily, this is a receptive bunch – they are always down for some learnin’.
 
-<img alt="Hula hooping" src="/assets/blog/talent-manager/hulahoop.JPG" class="align-left" />
+<img alt="Hula hooping" src="{{ site.baseurl }}/assets/blog/talent-manager/hulahoop.JPG" class="align-left" />
 
 **4:00 p.m.**: I take a good portion of the rest of the day to sit down and tackle my inbox and other small tasks; since I used to be one of the only Operations Specialists, I am still somehow involved in all of the things. It is quiet(er) in DC at this point, so I can focus on these items with fewer disruptions. If you must know, I have an inbox zero policy, and finagling my inbox to zero takes longer than I like to admit out loud.
 


### PR DESCRIPTION
No idea how these aren't broken on the current website because adding `site.baseurl` is a requirement of hosting on federalist.
