### PR TITLE
Add "View on GitHub" link to footer

### DIFF
--- a/_includes/footer/desktop.html
+++ b/_includes/footer/desktop.html
@@ -49,6 +49,9 @@
       <li>
         <a href="mailto:18F@gsa.gov">18F@gsa.gov</a>
       </li>
+      <li>
+        <a href="https://github.com/18F/beta.18f.gov">View on GitHub</a>
+      </li>
     </ul>
   </div>
 </nav>

--- a/_includes/footer/mobile.html
+++ b/_includes/footer/mobile.html
@@ -49,6 +49,9 @@
         <li>
           <a href="mailto:18F@gsa.gov">18F@gsa.gov</a>
         </li>
+        <li>
+          <a href="https://github.com/18F/beta.18f.gov">View on GitHub</a>
+        </li>
       </ul>
     </li>
   </ul>


### PR DESCRIPTION
Currently we don't have a link to GitHub on the site and this adds it.

This is what it looks like: 

<img width="156" alt="screen shot 2016-08-20 at 11 32 36 am" src="https://cloud.githubusercontent.com/assets/5249443/17863143/586d0772-684d-11e6-9063-9f60bb4b7d20.png">

cc: @gboone @elainekamlley 
