### PR TITLE
Attempt to speed up incremental builds

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,10 +6,15 @@ gem "jekyll", '~> 3.1'
 gem "html-proofer"
 
 group :jekyll_plugins do
-  gem 'jekyll-sitemap'
+  if ENV['FAST_BUILDS']
+    puts 'not using jekyll-archives because its sloooooooooow'
+  else
+    gem 'jekyll-archives', :git => 'https://github.com/jekyll/jekyll-archives.git'
+  end
+
   gem 'jekyll_pages_api'
   gem 'jekyll_pages_api_search'
-  gem 'jekyll-archives', :git => 'https://github.com/jekyll/jekyll-archives.git'
+  gem 'jekyll-sitemap'
   gem 'jekyll-paginate'
   gem 'jekyll-redirect-from'
   gem 'jekyll_frontmatter_tests'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,3 @@
-GIT
-  remote: https://github.com/jekyll/jekyll-archives.git
-  revision: 40823a4e16d81d7d0fb90736a7359144a15ea923
-  specs:
-    jekyll-archives (2.1.0)
-      jekyll (>= 2.4)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -110,7 +103,6 @@ PLATFORMS
 DEPENDENCIES
   html-proofer
   jekyll (~> 3.1)
-  jekyll-archives!
   jekyll-feed
   jekyll-paginate
   jekyll-redirect-from
@@ -123,4 +115,4 @@ DEPENDENCIES
   redcarpet
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Run each of the following steps to get the site up and running.
 3. `bundle install`
 4. `jekyll serve`
 
+To dramatically speed up rebuild times (from more than 20 seconds to around 5), you can also run `./serve` or `./build` for step 4. These are shorthand for a combination of commands that disable certain plugins. This is especially useful if you're drafting a blog post or formatting single pages.
+
 You should be able to see the site at: http://127.0.0.1:4000
 
 ## System security controls

--- a/_config-fast-builds.yml
+++ b/_config-fast-builds.yml
@@ -1,0 +1,8 @@
+gems:
+  - jekyll-sitemap
+  - jekyll-redirect-from
+  - jekyll-feed
+
+jekyll-archives: false
+jekyll_pages_api_search:
+  skip_index: true

--- a/build
+++ b/build
@@ -1,0 +1,5 @@
+if [ -n $FAST_BUILDS ]; then
+  export FAST_BUILDS=true
+fi
+
+bundle exec jekyll build --watch --incremental --config="_config.yml,_config-fast-builds.yml"

--- a/serve
+++ b/serve
@@ -1,0 +1,5 @@
+if [ -n $FAST_BUILDS ]; then
+  export FAST_BUILDS=true;
+fi
+
+bundle exec jekyll serve --watch --incremental --config="_config.yml,_config-fast-builds.yml"


### PR DESCRIPTION
Use an environment variable and a second config file to make incremental builds pretty quick (time decreased for a single page to build from ~15 seconds to ~3 seconds).

Run this with something like:

`export FAST_BUILDS=true && bundle exec jekyll serve --watch --config _config.yml,_config-fast-builds.yml`
